### PR TITLE
Add take snapshot button functionality

### DIFF
--- a/src/background/store.ts
+++ b/src/background/store.ts
@@ -11,7 +11,7 @@ const emptyState: AppState = {
   justTweeted: null,
   twitterAuth: 'not_authed',
   alert: null,
-  lastAction: null
+  mostRecentAction: null
 }
 
 function reducerNoLastAction(initialState: AppState = emptyState, action: Action): AppState {
@@ -173,7 +173,7 @@ function reducerNoLastAction(initialState: AppState = emptyState, action: Action
 function reducer(initialState: AppState = emptyState, action: Action): AppState {
   return {
     ...reducerNoLastAction(initialState, action),
-    lastAction: action
+    mostRecentAction: action
   }
 }
 

--- a/src/background/subscribe.ts
+++ b/src/background/subscribe.ts
@@ -20,7 +20,7 @@ export function subscribe(store: Store<AppState, Action>, browser: typeof window
     }
 
     // Take a screenshot if no screenshots currently present for the active tab
-    if (nextState.lastAction && nextState.lastAction.type === 'ACTIVE_TAB_DETECTED') {
+    if (nextState.mostRecentAction && nextState.mostRecentAction.type === 'ACTIVE_TAB_DETECTED') {
       if (!nextState.popup.connected) throw new Error('Popup should be connected')
       const activeTabId = nextState.popup.activeTab!.id!
       const activeTabFeedback = nextState.feedbackByTabId[activeTabId] || { screenshots: [] }
@@ -28,6 +28,12 @@ export function subscribe(store: Store<AppState, Action>, browser: typeof window
       if (!activeTabFeedback.screenshots.length) {
         takeScreenshot((nextState.popup as ConnectedPopupState).activeTab!, tabs, dispatchBackgroundActions)
       }
+    }
+
+    // Take a screenshot on request
+    if (nextState.mostRecentAction && nextState.mostRecentAction.type === 'CLICK_TAKE_SCREENSHOT') {
+      if (!nextState.popup.connected) throw new Error('Popup should be connected')
+      takeScreenshot((nextState.popup as ConnectedPopupState).activeTab!, tabs, dispatchBackgroundActions)
     }
 
     if (nextState.toBeTweeted && !prevState.toBeTweeted) {

--- a/src/popup/actions.ts
+++ b/src/popup/actions.ts
@@ -25,6 +25,9 @@ export function actions(dispatch: Dispatch<UserAction>, getState: () => AppState
     },
     emojiPicked(emoji: string): UserAction {
       return dispatch({ type: 'EMOJI_PICKED', payload: { emoji } })
+    },
+    clickTakeScreenshot(): UserAction {
+      return dispatch({ type: 'CLICK_TAKE_SCREENSHOT' })
     }
   }
 }

--- a/src/popup/app.tsx
+++ b/src/popup/app.tsx
@@ -32,7 +32,11 @@ function Authenticated({ feedback, dispatchUserActions }: AuthenticatedProps): J
         <div className="twitter-interface">
           <FeedbackEditor editorState={editorState} updateEditorState={dispatchUserActions.updateEditorState} />
           <Screenshots feedback={feedback} />
-          <ActionBar clickPost={dispatchUserActions.clickPost} emojiPicked={dispatchUserActions.emojiPicked} />
+          <ActionBar
+            clickPost={dispatchUserActions.clickPost}
+            emojiPicked={dispatchUserActions.emojiPicked}
+            clickTakeScreenshot={dispatchUserActions.clickTakeScreenshot}
+          />
         </div>
       </main>
     </div>

--- a/src/popup/components/action-bar.tsx
+++ b/src/popup/components/action-bar.tsx
@@ -2,8 +2,8 @@ import * as React from 'react'
 
 import { EmojiPicker } from './emoji-picker'
 
-const TakeSnapshotButton = () => (
-  <button className="svg-btn">
+const TakeSnapshotButton = ({ onClick }) => (
+  <button className="svg-btn" onClick={onClick}>
     <svg width="33" height="34" viewBox="0 0 33 34" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path
         id="Take Screenshot Button"
@@ -41,13 +41,14 @@ const AddHashtagButton = () => (
 type ActionBarProps = {
   clickPost: DispatchUserActions['clickPost']
   emojiPicked(emoji: string): void
+  clickTakeScreenshot: DispatchUserActions['clickTakeScreenshot']
 }
 
-export const ActionBar = ({ clickPost, emojiPicked }: ActionBarProps) => {
+export const ActionBar = ({ clickPost, emojiPicked, clickTakeScreenshot }: ActionBarProps) => {
   return (
     <div className="actions-bar">
       <div className="actions">
-        <TakeSnapshotButton />
+        <TakeSnapshotButton onClick={clickTakeScreenshot} />
         <AddImageButton />
         <AddHashtagButton />
         <EmojiPicker emojiPicked={emojiPicked} />

--- a/src/types/actions.ts
+++ b/src/types/actions.ts
@@ -7,6 +7,7 @@ type UserAction =
   | { type: 'UPDATE_EDITOR_STATE'; payload: { editorState: any } }
   | { type: 'CLICK_POST' }
   | { type: 'EMOJI_PICKED'; payload: { emoji: string } }
+  | { type: 'CLICK_TAKE_SCREENSHOT' }
 
 type BackgroundAction =
   | {
@@ -31,6 +32,7 @@ type DispatchUserActions = {
   updateEditorState(editorState: any): void
   clickPost(): void
   emojiPicked(emoji: string): void
+  clickTakeScreenshot(): void
 }
 
 type DispatchBackgroundActions = {

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -64,7 +64,7 @@ type AppStateNoLastAction = {
 }
 
 type AppState = AppStateNoLastAction & {
-  lastAction: null | Action
+  mostRecentAction: null | Action
 }
 
 type Feedback = any


### PR DESCRIPTION
Connected the snapshot button to backend state and subscription logic to take the snapshot.

Verified that the snapshot was being added to state. The popup UI is not updated to properly show the multiple snapshots (I'm assuming that is another task).
