### PR TITLE
strip www from host to get the domain

### DIFF
--- a/src/background/api.ts
+++ b/src/background/api.ts
@@ -1,10 +1,10 @@
-function tweetFormData(feedbackState: FeedbackState, host: string): FormData {
+function tweetFormData(feedbackState: FeedbackState, domain: string): FormData {
   const tweetData = new FormData()
 
   const status = feedbackState.editorState.getCurrentContent().getPlainText('\u0001')
   tweetData.append('status', status)
 
-  tweetData.append('host', host)
+  tweetData.append('domain', domain)
 
   // Adding all the screenshot files under the same form key - 'screenshots'.
   feedbackState.screenshots.forEach(screenshot => tweetData.append('screenshots', screenshot.blob, screenshot.name))
@@ -22,7 +22,7 @@ function makeTweetRequest(formData: FormData): Promise<Response> {
 
 export const postTweet = async (tab: TabInfo, chrome: typeof global.chrome, dispatchBackgroundActions: Dispatchers<BackgroundAction>) => {
   try {
-    const res = await makeTweetRequest(tweetFormData(tab.feedbackState, tab.host!))
+    const res = await makeTweetRequest(tweetFormData(tab.feedbackState, tab.domain!))
     if (res.status !== 201) {
       return dispatchBackgroundActions.postTweetFailure({
         tabId: tab.id,
@@ -43,20 +43,20 @@ export const postTweet = async (tab: TabInfo, chrome: typeof global.chrome, disp
   }
 }
 
-function makeHandleRequest(host: string): Promise<Response> {
-  const params = { domain: host }
+function makeHandleRequest(domain: string): Promise<Response> {
+  const params = { domain }
   const requestURL = new URL('v1/website', window.roarServerUrl)
   requestURL.search = new URLSearchParams(params).toString()
   return fetch(requestURL.toString())
 }
 
-export const fetchTwitterHandle = async (tabId: number, host: string, dispatchBackgroundActions: Dispatchers<BackgroundAction>) => {
+export const fetchTwitterHandle = async (tabId: number, domain: string, dispatchBackgroundActions: Dispatchers<BackgroundAction>) => {
   try {
     dispatchBackgroundActions.fetchHandleStart({ tabId })
-    const res = await makeHandleRequest(host)
+    const res = await makeHandleRequest(domain)
     const { twitter_handle } = await res.json()
-    return dispatchBackgroundActions.fetchHandleSuccess({ tabId, host, handle: twitter_handle })
+    return dispatchBackgroundActions.fetchHandleSuccess({ tabId, domain, handle: twitter_handle })
   } catch (error) {
-    return dispatchBackgroundActions.fetchHandleFailure({ tabId, host, error })
+    return dispatchBackgroundActions.fetchHandleFailure({ tabId, domain, error })
   }
 }

--- a/src/background/domain.ts
+++ b/src/background/domain.ts
@@ -1,0 +1,6 @@
+export const domainOf = (url: string | undefined): undefined | string => {
+  if (url && url.startsWith('http')) {
+    const { host } = new URL(url)
+    return host.replace(/^www\./, '')
+  }
+}

--- a/src/background/run.ts
+++ b/src/background/run.ts
@@ -18,7 +18,7 @@ export function run(backgroundWindow: Window, browser: typeof global.browser, ch
 
   store.on('popupConnect', state => {
     const tab = ensureActiveTab(state)
-    if (tab.isTweeting || !tab.host) return
+    if (tab.isTweeting || !tab.domain) return
 
     // Take a screenshot if no screenshots currently present for the active tab
     if (!tab.feedbackState.screenshots.length) {
@@ -27,8 +27,8 @@ export function run(backgroundWindow: Window, browser: typeof global.browser, ch
 
     // it the handle wasn't fetched before and the tab URL is valid,
     // start the fetch process
-    if (tab.feedbackState.hostTwitterHandle.status === 'NEW') {
-      fetchTwitterHandle(tab.id, tab.host, store.dispatchers)
+    if (tab.feedbackState.domainTwitterHandle.status === 'NEW') {
+      fetchTwitterHandle(tab.id, tab.domain, store.dispatchers)
     }
   })
 

--- a/src/background/screenshot.ts
+++ b/src/background/screenshot.ts
@@ -1,3 +1,5 @@
+import { domainOf } from './domain'
+
 function dataURItoBlob(dataURI: string): Blob {
   // convert base64 to raw binary data held in a string
   // doesn't handle URLEncoded DataURIs - see SO answer #6850276 for code that does this
@@ -26,7 +28,7 @@ export async function takeScreenshot(tab: TabInfo, tabs: typeof browser.tabs, di
     const moreTabInfo = await gettingTab
 
     const screenshotBlob = dataURItoBlob(screenshotUri)
-    const { host } = new URL(tab.url!)
+    const domain = domainOf(tab.url)
     dispatchBackgroundActions.screenshotCaptureSuccess({
       screenshot: {
         tab: {
@@ -35,7 +37,7 @@ export async function takeScreenshot(tab: TabInfo, tabs: typeof browser.tabs, di
           width: moreTabInfo.width!,
           height: moreTabInfo.height!,
         },
-        name: `${host} - ${new Date().toISOString()}.png`,
+        name: `${domain} - ${new Date().toISOString()}.png`,
         uri: screenshotUri,
         blob: screenshotBlob,
       },

--- a/src/popup/app.tsx
+++ b/src/popup/app.tsx
@@ -20,12 +20,12 @@ export function App({ state, dispatchUserActions }: AppProps): null | JSX.Elemen
     case 'authenticated': {
       const tab = activeTab(state)
       if (!tab) return null
-      if (tab.host) {
+      if (tab.domain) {
         return (
           <div className="app">
             <Authenticated
               feedback={tab.feedbackState}
-              host={tab.host}
+              domain={tab.domain}
               isTweeting={tab.isTweeting}
               user={state.auth.user}
               pickingEmoji={state.pickingEmoji}

--- a/src/popup/components/tweeting.tsx
+++ b/src/popup/components/tweeting.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
 
-export function Tweeting({ host }: { host: string }): JSX.Element {
-  return <p className="tweet-in-progress">Tweeting your feedback for {host}</p>
+export function Tweeting({ domain }: { domain: string }): JSX.Element {
+  return <p className="tweet-in-progress">Tweeting your feedback for {domain}</p>
 }

--- a/src/popup/views/authenticated.tsx
+++ b/src/popup/views/authenticated.tsx
@@ -8,7 +8,7 @@ import { EditingScreenshot } from '../components/editing-screenshot'
 
 type AuthenticatedProps = {
   feedback: FeedbackState
-  host: string
+  domain: string
   user: User
   isTweeting: boolean
   pickingEmoji: boolean
@@ -19,7 +19,7 @@ type AuthenticatedProps = {
 
 export function Authenticated({
   feedback,
-  host,
+  domain,
   isTweeting,
   user,
   pickingEmoji,
@@ -28,7 +28,7 @@ export function Authenticated({
   dispatchUserActions,
 }: AuthenticatedProps): JSX.Element | null {
   if (isTweeting) {
-    return <Tweeting host={host} />
+    return <Tweeting domain={domain} />
   }
 
   if (feedback.editingScreenshot) {

--- a/src/tests/happy-path.test.ts
+++ b/src/tests/happy-path.test.ts
@@ -76,13 +76,13 @@ describe('happy path', () => {
       expect(activeTab).to.have.property('active', true)
       expect(activeTab).to.have.property('isTweeting', false)
       expect(activeTab).to.have.property('url', 'https://zing.com/abc')
-      expect(activeTab).to.have.property('host', 'zing.com')
+      expect(activeTab).to.have.property('domain', 'zing.com')
       expect(activeTab.feedbackState).to.have.property('screenshots').that.eql([])
 
-      expect(state.tabs.get(17)).to.have.property('host', undefined)
+      expect(state.tabs.get(17)).to.have.property('domain', undefined)
     })
 
-    it("uses the tab's host as the handle as a placeholder prior to fetching the actual twitter handle", () => {
+    it("uses the tab's domain as the handle as a placeholder prior to fetching the actual twitter handle", () => {
       const state = getState()
       const activeTab = ensureActiveTab(state)
       expect(getPlainText(activeTab.feedbackState.editorState)).to.equal('@zing.com ')
@@ -117,7 +117,7 @@ describe('happy path', () => {
       expect(screenshot.tab.height).to.equal(900)
       expect(screenshot.blob).to.be.an.instanceof(Blob)
 
-      expect(activeTab.feedbackState.hostTwitterHandle.handle).to.equal('@zing')
+      expect(activeTab.feedbackState.domainTwitterHandle.handle).to.equal('@zing')
 
       expect(getPlainText(activeTab.feedbackState.editorState)).to.equal('@zing ')
     })
@@ -265,7 +265,7 @@ describe('happy path', () => {
 
       const body: FormData = opts!.body! as any
       expect(body.get('status')).to.equal('@zing This is some feedback')
-      expect(body.get('host')).to.equal('zing.com')
+      expect(body.get('domain')).to.equal('zing.com')
       const screenshot: any = body.get('screenshots') as any
       expect(screenshot.name.startsWith('zing.com')).to.equal(true)
       expect(screenshot.name.endsWith('.png')).to.equal(true)

--- a/src/tests/responders.test.ts
+++ b/src/tests/responders.test.ts
@@ -29,8 +29,8 @@ describe('responders', () => {
         active: false,
         isTweeting: false,
         url: 'https://original-url.com',
-        host: 'original-url.com',
-        feedbackState: newFeedbackState({ host: 'original-url.com' }),
+        domain: 'original-url.com',
+        feedbackState: newFeedbackState({ domain: 'original-url.com' }),
       })
 
       const stateUpdates = responders['chrome.tabs.onUpdated'](appState, {
@@ -43,7 +43,7 @@ describe('responders', () => {
       const updatedTab = stateUpdates.tabs!.get(17)!
 
       expect(updatedTab.url).to.equal('https://updated.com/abc')
-      expect(updatedTab.host).to.equal('updated.com')
+      expect(updatedTab.domain).to.equal('updated.com')
       expect(getPlainText(updatedTab.feedbackState.editorState)).to.equal('@updated.com ')
     })
   })

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,7 +35,7 @@ type ScreenshotState = {
 
 type TwitterHandleStatus = 'NEW' | 'IN_PROGRESS' | 'DONE'
 
-type HostTwitterHandle = {
+type DomainTwitterHandle = {
   status: TwitterHandleStatus
   handle: string | null
 }
@@ -49,7 +49,7 @@ type FeedbackState = {
   editingScreenshot: null | EditingScreenshotState
   screenshots: ReadonlyArray<Screenshot>
   editorState: Draft.EditorState
-  hostTwitterHandle: HostTwitterHandle
+  domainTwitterHandle: DomainTwitterHandle
 }
 
 type User = { photoUrl?: string }
@@ -62,7 +62,7 @@ type TabInfo = {
   active: boolean
   isTweeting: boolean
   url?: string
-  host?: string
+  domain?: string
   feedbackState: FeedbackState
 }
 
@@ -102,8 +102,8 @@ type UserAction =
 
 type BackgroundAction =
   | { type: 'fetchHandleStart'; payload: { tabId: number } }
-  | { type: 'fetchHandleSuccess'; payload: { tabId: number; host: string; handle: string } }
-  | { type: 'fetchHandleFailure'; payload: { tabId: number; host: string; error: any } }
+  | { type: 'fetchHandleSuccess'; payload: { tabId: number; domain: string; handle: string } }
+  | { type: 'fetchHandleFailure'; payload: { tabId: number; domain: string; error: any } }
   | { type: 'screenshotCaptureSuccess'; payload: { screenshot: Screenshot } }
   | { type: 'screenshotCaptureFailure'; payload: { error: any } }
   | { type: 'postTweetSuccess'; payload: { tabId: number } }


### PR DESCRIPTION
Fixes https://github.com/morehumaninternet/roar-extension/issues/68

Uses a regex to strip `www.` from the start of host to form `domain`.

Also sends `domain` as the FormData field for feedback, rather than host, which [this PR](https://github.com/morehumaninternet/roar-server/pull/27) made possible