### PR TITLE
remove old img styles no longer needed

### DIFF
--- a/scss/components/sign-in-page.scss
+++ b/scss/components/sign-in-page.scss
@@ -8,11 +8,6 @@
   flex-direction: column;
   position: relative;
 
-  img {
-    height: 128px;
-    width: 128px;
-  }
-
   button {
     border: none;
     outline: none;
@@ -23,12 +18,6 @@
     font-weight: bold;
     display: flex;
     align-items: center;
-
-    img {
-      padding: 3px;
-      height: 18px;
-      width: 18px;
-    }
   }
 
   p,


### PR DESCRIPTION
All images elements on sigin in page converted to svg file. No longer need img styles in sign-in-page.scss. 