### PR TITLE
wrap fetch calls to isolate distinct error reasons

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react-konva": "17.0.0-0",
     "redux": "4.0.1",
     "spinthatshit": "1.0.4",
+    "ts.data.json": "^1.5.0",
     "urijs": "1.19.1",
     "webextension-polyfill": "0.3.1"
   },

--- a/src/background/api-handlers.ts
+++ b/src/background/api-handlers.ts
@@ -1,0 +1,71 @@
+import * as api from './api'
+
+function tweetFormData(target: FeedbackTarget): FormData {
+  const tweetData = new FormData()
+
+  const status = target.feedbackState.editorState.getCurrentContent().getPlainText('\u0001')
+  tweetData.append('status', status)
+
+  if (target.feedbackTargetType === 'tab') {
+    tweetData.append('domain', target.domain!)
+  } else {
+    tweetData.append('help', 'true')
+  }
+
+  // Adding all the screenshot files under the same form key - 'images'.
+  target.feedbackState.images.forEach(image => tweetData.append('images', image.blob, image.name))
+
+  return tweetData
+}
+
+export const postTweet = async (target: FeedbackTarget, chrome: typeof global.chrome, dispatchBackgroundActions: Dispatchers<BackgroundAction>) => {
+  const targetId: FeedbackTargetId = target.id
+  dispatchBackgroundActions.postTweetStart({ targetId })
+
+  const result = await api.postFeedback(tweetFormData(target))
+  if (result.ok) {
+    chrome.tabs.create({ url: result.data.url, active: true })
+    return dispatchBackgroundActions.postTweetSuccess({ targetId })
+  }
+
+  // TODO: handle different types of errors differently with a common function
+  return dispatchBackgroundActions.postTweetFailure({
+    targetId,
+    error: {
+      message: `${result.reason} ${result.details}`,
+    },
+  })
+}
+
+export const fetchTwitterHandle = async (
+  tabId: number,
+  domain: string,
+  dispatchBackgroundActions: Dispatchers<BackgroundAction>,
+  handleCache: TwitterHandleCache
+) => {
+  dispatchBackgroundActions.fetchHandleStart({ tabId })
+
+  const cachedHandle = await handleCache.get(domain)
+  if (cachedHandle) return dispatchBackgroundActions.fetchHandleSuccess({ tabId, domain, handle: cachedHandle })
+
+  // If we didn't find the handle in the cache, fetch the request from the server
+  const result = await api.getWebsite(domain)
+  if (result.ok) {
+    if (result.data.twitter_handle) handleCache.set(domain, result.data.twitter_handle)
+    return dispatchBackgroundActions.fetchHandleSuccess({ tabId, domain, handle: result.data.twitter_handle })
+  }
+
+  // TODO: handle different types of errors differently with a common function
+  return dispatchBackgroundActions.fetchHandleFailure({ tabId, domain, error: { message: `${result.reason} ${result.details}` } })
+}
+
+export async function detectLogin(dispatchActions: Dispatchers<Action>, opts: { failIfNotLoggedIn?: boolean } = {}): Promise<void> {
+  const result = await api.getMe()
+  if (result.ok) {
+    return dispatchActions.authenticationSuccess(result.data)
+  }
+  // TODO: handle different types of errors differently with a common function
+  if (opts.failIfNotLoggedIn) {
+    dispatchActions.authenticationFailure({ error: { message: 'Not logged in.' } })
+  }
+}

--- a/src/background/listeners.ts
+++ b/src/background/listeners.ts
@@ -1,6 +1,7 @@
 import { AppStore } from './store'
 import * as images from './images'
-import { detectLogin, makeLogoutRequest, fetchTwitterHandle, postTweet } from './api'
+import { makeLogoutRequest } from './api'
+import { detectLogin, fetchTwitterHandle, postTweet } from './api-handlers'
 import { whenState } from '../redux-utils'
 import { ensureActiveFeedbackTarget, targetById, totalImages } from '../selectors'
 

--- a/src/background/run.ts
+++ b/src/background/run.ts
@@ -1,7 +1,7 @@
 import { AppStore, create } from './store'
 import { detectBrowser } from './browser-detection'
 import * as listeners from './listeners'
-import { detectLogin } from './api'
+import { detectLogin } from './api-handlers'
 import { monitorTabs } from './monitorTabs'
 import { createHandleCache } from './handle-cache'
 

--- a/src/tests/integration/happy-path.test.ts
+++ b/src/tests/integration/happy-path.test.ts
@@ -142,9 +142,6 @@ function happyPath(opts: { browser: SupportedBrowser }): void {
       before(() => {
         fetchMock.mock('https://test-roar-server.com/v1/feedback', { status: 201, body: { url: 'https://t.co/sometweethash' } })
       })
-      after(() => {
-        fetchMock.restore()
-      })
 
       it('posts feedback upon clicking the post button', async () => {
         const postButton = mocks.app().querySelector('.twitter-interface button.post-btn')! as HTMLButtonElement
@@ -155,7 +152,7 @@ function happyPath(opts: { browser: SupportedBrowser }): void {
 
         const [url, opts] = fetchMock.lastCall()!
         expect(url).to.equal('https://test-roar-server.com/v1/feedback')
-        expect(opts).to.have.all.keys('method', 'credentials', 'body')
+        expect(opts).to.have.all.keys('method', 'credentials', 'body', 'signal')
         expect(opts).to.have.property('method', 'POST')
         expect(opts).to.have.property('credentials', 'include')
 

--- a/src/tests/integration/logout.test.ts
+++ b/src/tests/integration/logout.test.ts
@@ -15,11 +15,6 @@ describe('logout', () => {
       fetchMock.mock({ url: 'https://test-roar-server.com/v1/logout', method: 'POST' }, 'OK')
     })
 
-    after(() => {
-      if (!fetchMock.done()) throw new Error('Fetch not called the expected number of times')
-      fetchMock.restore()
-    })
-
     it('transitions to a not_authed state and makes a POST to v1/logout when clicked', async () => {
       const logoutButton = mocks.app().querySelector('.logout-btn')! as HTMLButtonElement
       logoutButton.click()

--- a/src/tests/integration/mocks.tsx
+++ b/src/tests/integration/mocks.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
+import * as fetchMock from 'fetch-mock'
 import { last } from 'lodash'
 import { readFileSync } from 'fs'
 import * as sinon from 'sinon'
@@ -32,6 +33,8 @@ export type Mocks = {
 
 const popupHTML = readFileSync(`${process.cwd()}/html/popup.html`, { encoding: 'utf-8' })
 const screenshotUri = readFileSync(`${__dirname}/screenshotUri`, { encoding: 'utf-8' })
+
+fetchMock.config.overwriteRoutes = true
 
 export function createMocks(opts: CreateMocksOpts = {}): Mocks {
   const userAgent =
@@ -98,6 +101,9 @@ export function createMocks(opts: CreateMocksOpts = {}): Mocks {
       delete (global as any)[key]
     }
     chrome.reset()
+    const err = !fetchMock.done() && new Error('Fetch not called the expected number of times')
+    fetchMock.restore()
+    if (err) throw err
   }
 
   const app = () => popupWindow.document.querySelector('#app-container > .app') as HTMLDivElement

--- a/src/tests/integration/steps/authenticate-via-twitter.ts
+++ b/src/tests/integration/steps/authenticate-via-twitter.ts
@@ -25,11 +25,6 @@ function authenticateViaTwitterFirefox(mocks: Mocks): void {
     })
 
     after(() => {
-      if (!fetchMock.done()) throw new Error('Fetch not called the expected number of times')
-      fetchMock.restore()
-    })
-
-    after(() => {
       mocks.chrome.tabs.create.reset()
     })
 

--- a/src/tests/integration/steps/run-background.ts
+++ b/src/tests/integration/steps/run-background.ts
@@ -37,11 +37,6 @@ export function runBackground(mocks: Mocks, opts: RunBackgroundOpts = {}): void 
       })
     })
 
-    after(() => {
-      if (!fetchMock.done()) throw new Error('Fetch not called the expected number of times')
-      fetchMock.restore()
-    })
-
     it('loads window.store, which starts with an empty state', () => {
       const state = mocks.getState()
       expect(state.browserInfo).to.have.all.keys('browser', 'majorVersion')

--- a/src/tests/unit/api.test.ts
+++ b/src/tests/unit/api.test.ts
@@ -1,0 +1,81 @@
+import * as fetchMock from 'fetch-mock'
+import { expect } from 'chai'
+import { JsonDecoder } from 'ts.data.json'
+import * as api from '../../background/api'
+import { createMocks } from '../integration/mocks'
+
+describe('api', () => {
+  createMocks()
+
+  describe('fetchRoar', () => {
+    async function mockPost(status: number, body: any): Promise<api.FetchRoarResult<{ nice: string }>> {
+      fetchMock.mock({ url: 'https://test-roar-server.com/v1/my-cool-route', method: 'POST' }, { status, body })
+
+      return api.fetchRoar(
+        'v1/my-cool-route',
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ awesome: 'data' }),
+        },
+        JsonDecoder.object({ nice: JsonDecoder.string }, 'NiceResponseData')
+      )
+    }
+
+    it('resolves ok: true with the data when the response is in the 200 range with valid json', async () => {
+      const result = await mockPost(200, { nice: 'response' })
+      expect(result).to.have.property('ok', true)
+      expect(result).to.have.property('data').that.eql({ nice: 'response' })
+    })
+
+    it('resolves ok: false, reason: "response not json" when the response is in the 200 range but the body is not valid json', async () => {
+      const result = await mockPost(200, 'not json')
+      expect(result).to.have.property('ok', false)
+      expect(result).to.have.property('reason', 'response not json')
+      expect(result).to.have.property('text', 'not json')
+    })
+
+    it('resolves ok: false, reason: "response not expected data type" when the response is in the 200 range and the body is valid json but not the expected data type', async () => {
+      const result = await mockPost(200, { other: 'stuff' })
+      expect(result).to.have.property('ok', false)
+      expect(result).to.have.property('reason', 'response not expected data type')
+      expect(result).to.have.property('text', '{"other":"stuff"}')
+      expect(result).to.have.property('details', '<NiceResponseData> decoder failed at key "nice" with error: undefined is not a valid string')
+    })
+
+    it('resolves ok: false, reason: "bad request" when the response is 400', async () => {
+      const result = await mockPost(400, 'you forgot to set it to wumbo')
+      expect(result).to.have.property('ok', false)
+      expect(result).to.have.property('reason', 'bad request')
+      expect(result).to.have.property('details', 'you forgot to set it to wumbo')
+    })
+
+    it('resolves ok: false, reason: "unauthorized" when the response is 401', async () => {
+      const result = await mockPost(401, 'Unauthorized')
+      expect(result).to.have.property('ok', false)
+      expect(result).to.have.property('reason', 'unauthorized')
+    })
+
+    it('resolves ok: false, reason: "service down" when the response is 503', async () => {
+      const result = await mockPost(503, 'Twitter down')
+      expect(result).to.have.property('ok', false)
+      expect(result).to.have.property('reason', 'service down')
+      expect(result).to.have.property('details', 'Twitter down')
+    })
+
+    it('resolves ok: false, reason: "server down" when the response is in the 500 range', async () => {
+      const result = await mockPost(500, 'uh oh')
+      expect(result).to.have.property('ok', false)
+      expect(result).to.have.property('reason', 'server down')
+      expect(result).to.have.property('details', 'uh oh')
+    })
+
+    it('resolves ok: false, reason: "unknown status" when the response has some other status', async () => {
+      const result = await mockPost(418, "I'm a teapot")
+      expect(result).to.have.property('ok', false)
+      expect(result).to.have.property('reason', 'unknown status')
+      expect(result).to.have.property('details', "I'm a teapot")
+      expect(result).to.have.property('status', 418)
+    })
+  })
+})

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,7 +51,7 @@ type CharacterLimit = {
   percentageCompleted: number
 }
 
-type User = { photoUrl?: string }
+type User = { photoUrl: null | string }
 
 type Auth = { state: 'not_authed' } | { state: 'auth_failed' } | { state: 'authenticating' } | { state: 'authenticated'; user: User }
 
@@ -134,7 +134,7 @@ type UserAction =
   | { type: 'popupConnect' }
   | { type: 'popupDisconnect' }
   | { type: 'signInWithTwitter' }
-  | { type: 'authenticationSuccess'; payload: { photoUrl?: string } }
+  | { type: 'authenticationSuccess'; payload: { photoUrl: null | string } }
   | { type: 'authenticationFailure'; payload: { error: any } }
   | { type: 'dismissAlert' }
   | { type: 'updateEditorState'; payload: { editorState: any } }
@@ -151,7 +151,7 @@ type UserAction =
 
 type BackgroundAction =
   | { type: 'fetchHandleStart'; payload: { tabId: number } }
-  | { type: 'fetchHandleSuccess'; payload: { tabId: number; domain: string; handle: string } }
+  | { type: 'fetchHandleSuccess'; payload: { tabId: number; domain: string; handle: null | string } }
   | { type: 'fetchHandleFailure'; payload: { tabId: number; domain: string; error: any } }
   | { type: 'postTweetStart'; payload: { targetId: FeedbackTargetId } }
   | { type: 'postTweetSuccess'; payload: { targetId: FeedbackTargetId } }


### PR DESCRIPTION
Wraps api calls so that we can classify errors much better. Working toward including user-friendly alerts, but this is worth checking in as-is.