### PR TITLE
Change user avatar dropdown hover syntax. Resolve the issue logout button overlap with close button.

### DIFF
--- a/scss/components/user-avatar.scss
+++ b/scss/components/user-avatar.scss
@@ -23,7 +23,7 @@ $caret-radius: 12px;
 
   // Hide the dropdown content whenever not being hovered over
   &:not(:hover) .dropdown-content {
-    opacity: 0;
+    display: none;
   }
 
   .dropdown-content {


### PR DESCRIPTION
![Screen Shot 2020-12-03 at 6 10 46 PM](https://user-images.githubusercontent.com/16155615/101103297-2d395d00-3597-11eb-9b48-4ff19872c304.png)
