### PR TITLE
fainter pink for non-progress circle

### DIFF
--- a/scss/components/action-bar.scss
+++ b/scss/components/action-bar.scss
@@ -34,9 +34,9 @@
         fill: none;
         stroke-linecap: round;
         animation: progress 1s ease-out forwards;
-        stroke: #ebeef0;
-        &.progress {
-          stroke: $human-pink;
+        stroke: $human-pink;
+        &:not(.progress) {
+          opacity: 0.4;
         }
       }
       text {
@@ -45,7 +45,7 @@
         fill: $human-pink;
       }
       &.warning {
-        circle.progress {
+        circle {
           stroke: $human-yellow-warning;
         }
         text {


### PR DESCRIPTION
Looks good in light and dark mode and for the warning circle

![image](https://user-images.githubusercontent.com/6589960/101509558-e3f65e00-3946-11eb-8e2c-2e8173239713.png)
![image](https://user-images.githubusercontent.com/6589960/101509598-ee185c80-3946-11eb-9f7e-26a5d86aaba4.png)
![image](https://user-images.githubusercontent.com/6589960/101509792-261f9f80-3947-11eb-9fef-ff328d2a2a66.png)
