### PR TITLE
applies a handleDecorator once when calling prependHandle

### DIFF
--- a/scss/components/feedback-editor.scss
+++ b/scss/components/feedback-editor.scss
@@ -7,6 +7,10 @@
   overflow-wrap: break-word;
 }
 
+.twitter-handle {
+  color: $human-pink;
+}
+
 .link-tooltip {
   position: fixed;
   z-index: 2;

--- a/src/popup/components/feedback-editor.tsx
+++ b/src/popup/components/feedback-editor.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { Editor, EditorState } from 'draft-js'
 import { hasParent } from '../../utils'
-import { addTooltip } from '../../draft-js-utils'
 import ToolTip from './tooltip'
 
 type FeedbackEditorProps = {
@@ -19,11 +18,9 @@ const styleMap = {
 }
 
 export function FeedbackEditor({ editorState, hovering, updateEditorState, hoverOver, twitterHandle }: FeedbackEditorProps): JSX.Element {
-  const HANDLE_REGEX = /\@[\w\.\-]+/g
-
   React.useEffect(() => {
     const listener = event => {
-      if (hasParent(event.target, '.tooltip-hover-element')) {
+      if (hasParent(event.target, '.twitter-handle')) {
         const hoverElement = event.target as HTMLElement
         const { height, width, top, left } = hoverElement.getBoundingClientRect()
         hoverOver({ hovering: { active: true, height, width, top, left } })
@@ -36,13 +33,11 @@ export function FeedbackEditor({ editorState, hovering, updateEditorState, hover
     return () => window.removeEventListener('mouseover', listener)
   })
 
-  const nextEditorState = addTooltip(editorState, HANDLE_REGEX)
-
   return (
     <>
       <Editor
         placeholder="What's your feedback?"
-        editorState={nextEditorState}
+        editorState={editorState}
         onChange={editorState => updateEditorState({ editorState })}
         customStyleMap={styleMap}
       />

--- a/src/tests/integration/handle-does-not-exist.test.ts
+++ b/src/tests/integration/handle-does-not-exist.test.ts
@@ -11,7 +11,7 @@ describe('twitter handle does not exist for the domain', () => {
 
   describe('when we are hovering over the handle', () => {
     it('does not render the tooltip to the screen', () => {
-      const handle = mocks.app().querySelector('.tooltip-hover-element')! as HTMLDivElement
+      const handle = mocks.app().querySelector('.twitter-handle')! as HTMLDivElement
       const event = new mocks.popupWindow.MouseEvent('mouseover', { bubbles: true })
       handle.dispatchEvent(event)
 

--- a/src/tests/integration/handle-in-progress.test.ts
+++ b/src/tests/integration/handle-in-progress.test.ts
@@ -12,7 +12,7 @@ describe('twitter handle fetching in progress', () => {
 
   describe('when we are hovering over the handle', () => {
     it('renders that fetching the handle is in progress', () => {
-      const handle = mocks.app().querySelector('.tooltip-hover-element')! as HTMLDivElement
+      const handle = mocks.app().querySelector('.twitter-handle')! as HTMLDivElement
       const event = new mocks.popupWindow.MouseEvent('mouseover', { bubbles: true })
       handle.dispatchEvent(event)
 
@@ -24,7 +24,7 @@ describe('twitter handle fetching in progress', () => {
       resolveHandle()
       await mocks.whenState(state => ensureActiveTab(state).feedbackState.twitterHandle.status === 'DONE')
 
-      const handle = mocks.app().querySelector('.tooltip-hover-element')! as HTMLDivElement
+      const handle = mocks.app().querySelector('.twitter-handle')! as HTMLDivElement
       const event = new mocks.popupWindow.MouseEvent('mouseover', { bubbles: true })
       handle.dispatchEvent(event)
 

--- a/src/tests/integration/handle-tooltip.test.ts
+++ b/src/tests/integration/handle-tooltip.test.ts
@@ -18,7 +18,7 @@ describe('handle tooltip', () => {
 
   describe('when we are hovering over the handle', () => {
     it('renders a tooltip', () => {
-      const handle = mocks.app().querySelector('.tooltip-hover-element')! as HTMLDivElement
+      const handle = mocks.app().querySelector('.twitter-handle')! as HTMLDivElement
       const event = new mocks.popupWindow.MouseEvent('mouseover', { bubbles: true })
       handle.dispatchEvent(event)
 


### PR DESCRIPTION
Closes #138 . 

The main bug fix is that we only apply the decorator once when calling `prependHandle`, rather than calling it every time we type in the feedback editor.

However this has 2 extra benefits - the twitter handle is made as an immutable entity so individual characters within it may not be deleted. Second, we can apply the pink style directly to the `twitter-handle` class.

A final benefit is that I think I kind of get how draft-js works now! 🤣 