### PR TITLE
adding images go after

### DIFF
--- a/src/popup/components/images.tsx
+++ b/src/popup/components/images.tsx
@@ -43,9 +43,6 @@ export function Images({ feedback, startEditingImage, clickDeleteImage }: Images
 
   return (
     <div className="images">
-      {range(feedback.addingImages).map(n => (
-        <ImageSpinner key={n} />
-      ))}
       {feedback.images.map((image, index) => (
         <ImageThumbnail
           key={`${image.uri}_${index}`}
@@ -53,6 +50,9 @@ export function Images({ feedback, startEditingImage, clickDeleteImage }: Images
           startEditingImage={() => startEditingImage({ imageIndex: index })}
           clickDeleteImage={() => clickDeleteImage({ imageIndex: index })}
         />
+      ))}
+      {range(feedback.addingImages).map(n => (
+        <ImageSpinner key={n} />
       ))}
     </div>
   )


### PR DESCRIPTION
The added images get [appended at the end](https://github.com/morehumaninternet/roar-extension/blob/1cd677f20d20de13c6c7d6c62451bede961fc691/src/background/responders.ts#L167), so it makes more sense for the spinners to go at the end where the images will eventually appear.