### PR TITLE
adds loading spinner when app is first loading

### DIFF
--- a/build.js
+++ b/build.js
@@ -30,6 +30,7 @@ const pink = chalk.hex('#fa759e')
 const green = chalk.hex('#6FCF97')
 const gold = chalk.hex('#FFCA00')
 const lightBlue = chalk.hex('#4a81bc')
+const purple = chalk.hex('#00f000')
 const normalText = blue
 const emphasis = pink.bold
 
@@ -46,6 +47,7 @@ const commands = [
     command: `npm run scss -- ${watchFlag}`
   },
   bundleCommand('popup', gold),
+  bundleCommand('not-a-webpage', gold),
   bundleCommand('background', lightBlue),
 ]
 

--- a/html/not-a-webpage.html
+++ b/html/not-a-webpage.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <title>Roar</title>
+    <meta charset="UTF-8">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
+    <link href="../bundled/popup.css" rel="stylesheet">
+  </head>
+  <body>
+    <div id="app-container">
+      <div class="app">
+        <div class="alert whole-page">
+          <div className="alert-message">
+            <div>Roar does not work on this tab because it is not a web page.</div>
+            <div>Please open Roar on a web page to try again.</div>
+          </div>
+          <button id="close-btn" class="close-btn">
+            <svg width="26" height="26" viewBox="0 0 26 26" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <g id="Close Button">
+                <circle id="Ellipse 1" cx="13" cy="13" r="13" />
+                <path d="M18.6386 6.23385L19.7662 7.36141C20.0779 7.6732 20.0779 8.17797 19.7662 8.48896L8.48896 19.7662C8.17717 20.0779 7.6724 20.0779 7.36141 19.7662L6.23385 18.6386C5.92205 18.3268 5.92205 17.822 6.23385 17.511L17.511 6.23385C17.822 5.92205 18.3276 5.92205 18.6386 6.23385Z" />
+                <path d="M19.7662 18.6386L18.6386 19.7662C18.3268 20.0779 17.822 20.0779 17.511 19.7662L6.23385 8.48896C5.92205 8.17717 5.92205 7.6724 6.23385 7.36141L7.36141 6.23385C7.6732 5.92205 8.17797 5.92205 8.48896 6.23385L19.7662 17.511C20.0779 17.822 20.0779 18.3276 19.7662 18.6386Z" />
+              </g>
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  </body>
+  <script type="text/javascript" src="../bundled/not-a-webpage.js"></script>
+</html>

--- a/html/popup.html
+++ b/html/popup.html
@@ -8,7 +8,13 @@
   </head>
   <body>
     <div id="app-container">
-      <div class="app"></div>
+      <div class="app">
+        <div class="authenticating">
+          <div class="authenticating-spinner">
+
+          </div>
+        </div>
+      </div>
     </div>
     <script type="text/javascript" src="../bundled/popup.js"></script>
   </body>

--- a/scss/components/authenticating.scss
+++ b/scss/components/authenticating.scss
@@ -1,6 +1,7 @@
 .authenticating {
   background-color: var(--background-color);
 
+  min-height: 388px;
   height: 100%;
   width: 100%;
 

--- a/src/not-a-webpage/index.ts
+++ b/src/not-a-webpage/index.ts
@@ -1,0 +1,1 @@
+document.getElementById('close-btn')!.addEventListener('click', () => window.close())


### PR DESCRIPTION
Work in progress - the general idea is to add a loading spinner for the whole page while React is busy painting so that the user knows something is going on.

This view should take up the same view height as the rest of the extension, so I used a magic number of `388px` to do that. An issue is that the view when you're not on a webpage is an alert that should not be that high.

The good news is that we should always know ahead of time whether you're in one view or the other and can use [browser.browserAction.setPopup](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/setPopup) to change the view ahead of time so that when the user clicks the popup the proper view loads and there is no glitch where a 388px high view loads and then is quickly replaced by a smaller alert.

This approach feels a bit hacky as we're duplicating work to some extent by inlining the `Alert` react component and just making the `not-a-webpage.html` but I think it's a reasonable approach. 

Another thought that's coming to mind is what if the user uses dark mode. Currently that's not handled, so would we have 2 `.html` files? One for dark mode and one for light mode? At that point we may want to generate these HTML files from React rather than relying on copy/paste - which could get out of hand very fast.

If we like this, we might also consider having using a similar approach for the `NotAuthed` view when we know the user is not authenticated and render a static screen with a link. Then, in the `popup.html` (which we might rename as there would be several htmls describing the popup) we could inline the buttons so that the loading spinner is just in the upper half and the user would immediately see the buttons.

Thoughts?

![image](https://user-images.githubusercontent.com/6589960/105519936-0c90a800-5ca8-11eb-9402-7f3153d212d9.png)
![image](https://user-images.githubusercontent.com/6589960/105519987-19ad9700-5ca8-11eb-8009-b9a296cd67a9.png)
